### PR TITLE
Feat/tech 197

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -82,7 +82,11 @@
       "userIdentification": "User identification",
       "value": "Value",
       "usdc": "USDC",
-      "status": "Purchase status"
+      "status": "Purchase status",
+      "paid": "Paid",
+      "failed": "Failed",
+      "processing": "Processing",
+      "refunded": "Refunded"
     },
     "list": {
       "title": "Purchases List",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -78,7 +78,11 @@
       "userIdentification": "Identificação do usuário",
       "value": "Valor",
       "usdc": "USDC",
-      "status": "Status da compra"
+      "status": "Status da compra",
+      "paid": "Pago",
+      "failed": "Falhou",
+      "processing": "Processando",
+      "refunded": "Reembolsado"
     },
     "list": {
       "search": "Procurar por email...",

--- a/src/pages/PurchasesPage/PurchasesListSection/index.tsx
+++ b/src/pages/PurchasesPage/PurchasesListSection/index.tsx
@@ -36,7 +36,6 @@ function PurchasesListSection(): JSX.Element {
 
   const filterPurchasesByStatus = (nonFilteredPurchases: PersonPayment[]) => 
     (nonFilteredPurchases.filter((purchaseData: PersonPayment) => {
-      console.log(purchaseData.status)
         if (selectedStatus[purchaseData.status]) return purchaseData; 
         return null;
       })
@@ -83,7 +82,7 @@ function PurchasesListSection(): JSX.Element {
                 onChange={handleStatusChange}
                 checked={selectedStatus[status]}
                 />
-                <S.Span>{status}</S.Span>
+                <S.Span>{t(`attributes.${status}`)}</S.Span>
             </>
           )
         )}

--- a/src/pages/PurchasesPage/PurchasesListSection/index.tsx
+++ b/src/pages/PurchasesPage/PurchasesListSection/index.tsx
@@ -34,11 +34,11 @@ function PurchasesListSection(): JSX.Element {
     setSelectedStatus({ ...selectedStatus, [value]: !selectedStatus[value] });
   };
 
-  const filterPurchasesByStatus = (nonFilteredPurchases: PersonPayment[]) => 
-    (nonFilteredPurchases.filter((purchaseData: PersonPayment) => {
-        if (selectedStatus[purchaseData.status]) return purchaseData; 
-        return null;
-      })
+  const filterPurchasesByStatus = (nonFilteredPurchases: PersonPayment[]) =>
+  (nonFilteredPurchases.filter((purchaseData: PersonPayment) => {
+    if (selectedStatus[purchaseData.status]) return purchaseData;
+    return null;
+  })
   );
 
   const fetchPurchases = useCallback(async () => {
@@ -74,17 +74,17 @@ function PurchasesListSection(): JSX.Element {
       <S.CheckboxContainer>
         {Object.keys(defaultStatusSelection).map((status: any) => (
           <>
-            <S.Checkbox 
-                key={status}
-                name="status"
-                type="checkbox"
-                value={status}
-                onChange={handleStatusChange}
-                checked={selectedStatus[status]}
-                />
-                <S.Span>{t(`attributes.${status}`)}</S.Span>
-            </>
-          )
+            <S.Checkbox
+              key={status}
+              name="status"
+              type="checkbox"
+              value={status}
+              onChange={handleStatusChange}
+              checked={selectedStatus[status]}
+            />
+            <S.Span>{t(`attributes.${status}`)}</S.Span>
+          </>
+        )
         )}
       </S.CheckboxContainer>
       <S.SearchBar

--- a/src/pages/PurchasesPage/PurchasesListSection/index.tsx
+++ b/src/pages/PurchasesPage/PurchasesListSection/index.tsx
@@ -13,12 +13,14 @@ interface StatusObject {
 function PurchasesListSection(): JSX.Element {
   const [purchases, setPurchases] = useState<PersonPayment[]>([]);
   const defaultStatusSelection = {
-    "processing": true,
-    "refunded": true,
-    "paid": true,
-    "failed": true
-  }
-  const [selectedStatus, setSelectedStatus] = useState<StatusObject>(defaultStatusSelection);
+    processing: true,
+    refunded: true,
+    paid: true,
+    failed: true,
+  };
+  const [selectedStatus, setSelectedStatus] = useState<StatusObject>(
+    defaultStatusSelection,
+  );
   const { getPersonPayments } = usePersonPayments();
   const { t } = useTranslation("translation", {
     keyPrefix: "purchases",
@@ -35,11 +37,10 @@ function PurchasesListSection(): JSX.Element {
   };
 
   const filterPurchasesByStatus = (nonFilteredPurchases: PersonPayment[]) =>
-  (nonFilteredPurchases.filter((purchaseData: PersonPayment) => {
-    if (selectedStatus[purchaseData.status]) return purchaseData;
-    return null;
-  })
-  );
+    nonFilteredPurchases.filter((purchaseData: PersonPayment) => {
+      if (selectedStatus[purchaseData.status]) return purchaseData;
+      return null;
+    });
 
   const fetchPurchases = useCallback(async () => {
     try {
@@ -84,8 +85,7 @@ function PurchasesListSection(): JSX.Element {
             />
             <S.Span>{t(`attributes.${status}`)}</S.Span>
           </>
-        )
-        )}
+        ))}
       </S.CheckboxContainer>
       <S.SearchBar
         placeholder={t("list.search")}

--- a/src/pages/PurchasesPage/PurchasesListSection/styles.ts
+++ b/src/pages/PurchasesPage/PurchasesListSection/styles.ts
@@ -95,3 +95,28 @@ export const SearchBar = styled.input`
   border-radius: 8px;
   background-color: ${({ theme }) => theme.colors.gray10};
 `;
+
+export const CheckboxContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const Checkbox = styled.input`
+  accent-color: ${({ theme }) => theme.colors.green30};
+  margin: 5px 7px 30px 4px;
+  display: inline-block;
+  vertical-align: middle;
+  transform: scale(1.5);
+`;
+
+export const Span = styled.span`
+  margin: 5px 18px 30px 4px;
+  display: inline-block;
+  vertical-align: middle;
+  color: ${({ color, theme }) => color || theme.colors.darkGray};
+
+  ::first-letter {
+    text-transform: uppercase;
+  }
+`;


### PR DESCRIPTION
# Description

- adds a Purchase status checkbox filter

## Does this pull request close any open issues?

- [#TECH-197](https://ribon.atlassian.net/browse/TECH-197?atlOrigin=eyJpIjoiMDY5YjZhZDU1OTE2NGY0MjhkYzNkYWQ1NDZmMzJiZTIiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Run the server and go to "Purchases" ("Pagamentos") page
- Try and use the filter 
- OBS: I would recommend to check your backend to see if there are different "PersonPayment" with different status to check if the filter works. If there aren't and you want to run locally, try: `PersonPayment.create!(offer_id:1, payment_method:1, person: Person.last, status:"paid"*, integration:Integration.last, paid_date:"2023-01-10")`

*paid, failed, processing and refunded are the options