### PR TITLE
Tech/244

### DIFF
--- a/src/pages/NonProfitsPage/NonProfitsDetailsPage/index.tsx
+++ b/src/pages/NonProfitsPage/NonProfitsDetailsPage/index.tsx
@@ -112,7 +112,7 @@ function NonProfitsDetailsPage(): JSX.Element {
             <S.RightSection>
               <S.ItemBox>
                 <InfoName>{t("details.attributes.cardCause")}</InfoName>
-                <S.CardImage src={nonProfit?.causeCardImage} />
+                <S.CardImage src={nonProfit?.cause.coverImage} />
               </S.ItemBox>
             </S.RightSection>
           </S.Container>

--- a/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
+++ b/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
@@ -168,6 +168,15 @@ function UpsertNonProfitPage({ isEdit }: Props) {
     }
   };
 
+  const handleCauseCoverImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const coverImage = e.target.files![0];
+
+    setFile(URL.createObjectURL(coverImage));
+    if (NonProfitObject()) {
+      setValue("cause.coverImage", coverImage as File);
+    }
+  };
+
   const fetchCauses = useCallback(async () => {
     try {
       const allCauses = await getCauses();
@@ -290,8 +299,8 @@ function UpsertNonProfitPage({ isEdit }: Props) {
               <S.ItemBox>
                 <InfoName>{t("attributes.causeCardImage")}</InfoName>
                 <FileUpload
-                  onChange={handleLogoChange}
-                  logo={NonProfitObject().logo}
+                  onChange={handleCauseCoverImageChange}
+                  logo={NonProfitObject().cause?.coverImage}
                   value={file}
                 />
                 <S.ImageRecommendation>

--- a/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
+++ b/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
@@ -168,7 +168,9 @@ function UpsertNonProfitPage({ isEdit }: Props) {
     }
   };
 
-  const handleCauseCoverImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleCauseCoverImageChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     const coverImage = e.target.files![0];
 
     setFile(URL.createObjectURL(coverImage));

--- a/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
+++ b/src/pages/NonProfitsPage/UpsertNonProfitPage/index.tsx
@@ -36,7 +36,8 @@ function UpsertNonProfitPage({ isEdit }: Props) {
   const { gray10, gray40, gray30, red30 } = theme.colors;
   const [statusCheckbox, setStatusCheckbox] = useState(true);
   const [stories, setStories] = useState<CreateStory[]>([]);
-  const [file, setFile] = useState<string>("");
+  const [logoFile, setLogoFile] = useState<string>("");
+  const [coverImageFile, setCoverImageFile] = useState<string>("");
   const navigate = useNavigate();
   const { id } = useParams();
   const { createNonProfit, getNonProfit, updateNonProfit } = useNonProfits();
@@ -162,7 +163,7 @@ function UpsertNonProfitPage({ isEdit }: Props) {
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const logo = e.target.files![0];
 
-    setFile(URL.createObjectURL(logo));
+    setLogoFile(URL.createObjectURL(logo));
     if (NonProfitObject()) {
       setValue("logo", logo as File);
     }
@@ -173,7 +174,7 @@ function UpsertNonProfitPage({ isEdit }: Props) {
   ) => {
     const coverImage = e.target.files![0];
 
-    setFile(URL.createObjectURL(coverImage));
+    setCoverImageFile(URL.createObjectURL(coverImage));
     if (NonProfitObject()) {
       setValue("cause.coverImage", coverImage as File);
     }
@@ -291,7 +292,7 @@ function UpsertNonProfitPage({ isEdit }: Props) {
                 <FileUpload
                   onChange={handleLogoChange}
                   logo={NonProfitObject().logo}
-                  value={file}
+                  value={logoFile}
                 />
                 <S.ImageRecommendation>
                   {t("attributes.imageRecommendation", { size: "300x300" })}
@@ -303,7 +304,7 @@ function UpsertNonProfitPage({ isEdit }: Props) {
                 <FileUpload
                   onChange={handleCauseCoverImageChange}
                   logo={NonProfitObject().cause?.coverImage}
-                  value={file}
+                  value={coverImageFile}
                 />
                 <S.ImageRecommendation>
                   {t("attributes.imageRecommendation", { size: "600x560" })}

--- a/src/types/apiResponses/cause.ts
+++ b/src/types/apiResponses/cause.ts
@@ -1,4 +1,5 @@
 export interface CreateCause {
   id?: number;
   name: string;
+  coverImage?: any;
 }

--- a/src/types/apiResponses/nonProfit.ts
+++ b/src/types/apiResponses/nonProfit.ts
@@ -1,3 +1,4 @@
+import { CreateCause } from "./cause";
 import { CreateStory } from "./story";
 
 export interface CreateNonProfit {
@@ -10,4 +11,5 @@ export interface CreateNonProfit {
   causeCardImage?: any;
   causeId: number;
   storiesAttributes?: CreateStory[];
+  cause?: CreateCause;
 }

--- a/src/types/entities/Cause.ts
+++ b/src/types/entities/Cause.ts
@@ -6,4 +6,5 @@ export default interface Cause {
   name: string;
   pools: Pool[];
   nonProfits: NonProfit[];
+  coverImage?: string;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,5 @@
 export const RIBON_API =
-  process.env.REACT_APP_RIBON_API ||
-  "http://ribon-core-api-dev.us-east-1.elasticbeanstalk.com/";
+  process.env.REACT_APP_RIBON_API || "https://dapp-dev-api.ribon.io/";
 
 export const TOKEN_KEY = "token";
 


### PR DESCRIPTION
# Description

- We were having problems with rendering the cause cover image on the nonprofit details and edit page (the logo was also where the cover image was supposed to be)

# Necessary changes

- Referenced the correct image
 
## Does this pull request close any open issues?

- [#tech-244](https://ribon.atlassian.net/browse/TECH-244?atlOrigin=eyJpIjoiMjYyOTBiOTJlNGFlNDdjMDgzM2EwZmMyMTk1NWY4OGMiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Go on any non profit details page and make sure that the logo and the card cover image are different (if necessary, check on the api for reference)
- Access the non profit editing page and try to upload a different image (to both logo and cause cover image) to check if it saves accordingly
