### PR TITLE
fix: fixes purchases list search

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -91,7 +91,7 @@
     },
     "list": {
       "title": "Purchases List",
-      "search": "Search by email...",
+      "search": "Search by user identification...",
       "next": "next >",
       "previous": "< previous",
       "refundModal": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -91,7 +91,7 @@
     },
     "list": {
       "title": "Lista de Pagamentos",
-      "search": "Procurar por email...",
+      "search": "Procurar por identificação do usuário...",
       "next": "próximo >",
       "previous": "< anterior",
       "refundModal": {

--- a/src/pages/PurchasesPage/PurchaseItems/index.tsx
+++ b/src/pages/PurchasesPage/PurchaseItems/index.tsx
@@ -53,7 +53,7 @@ function PurchaseItems({ purchases, fetchPurchases, searchTerm }: Props) {
       if (searchTerm === "") {
         return purchaseData;
       } else if (
-        purchaseData?.person?.customer?.email
+        purchaseData?.payerIdentification
           .toLowerCase()
           .includes(searchTerm.toLowerCase())
       ) {


### PR DESCRIPTION
# Description

- Since we updated person payments for using user id, the search by email was not working on purchases page, so this is a simple fix to make it work again

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Try to search by user identification on purchases list
