### PR TITLE
chore: changes references from api/v1 to managers/v1

### DIFF
--- a/generators/templates/serviceAPI.test.ts.hbs
+++ b/generators/templates/serviceAPI.test.ts.hbs
@@ -6,4 +6,4 @@ import
 = jest.fn(); }); it("expects to send a get request with the correct info: url,
 params and headers", () => {
 {{camelCase name}}Api.exampleFunction();
-expect(api.get).toHaveBeenCalledWith("/api/v1/sample_url"); }); }); });
+expect(api.get).toHaveBeenCalledWith("/managers/v1/sample_url"); }); }); });

--- a/src/hooks/apiHooks/useUploadFile/index.ts
+++ b/src/hooks/apiHooks/useUploadFile/index.ts
@@ -4,7 +4,7 @@ import { RIBON_API } from "utils/constants";
 export function useUploadFile(file: File) {
   const upload = new DirectUpload(
     file,
-    `${RIBON_API}/api/v1/rails/active_storage/direct_uploads`,
+    `${RIBON_API}/managers/v1/rails/active_storage/direct_uploads`,
   );
 
   return upload;

--- a/src/services/api/articlesApi/index.test.ts
+++ b/src/services/api/articlesApi/index.test.ts
@@ -12,7 +12,7 @@ describe("articlesApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       articlesApi.getArticlesList({});
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/news/articles", {
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/news/articles", {
         params,
       });
     });
@@ -34,7 +34,7 @@ describe("articlesApi", () => {
     it("expects to send a post request with the correct info: url and params", () => {
       articlesApi.createArticle(data);
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/news/articles", data);
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/news/articles", data);
     });
   });
 
@@ -57,7 +57,10 @@ describe("articlesApi", () => {
     it("expects to send a put request with the correct info: url and params", () => {
       articlesApi.updateArticle(1, data);
 
-      expect(api.put).toHaveBeenCalledWith(`/api/v1/news/articles/${id}`, data);
+      expect(api.put).toHaveBeenCalledWith(
+        `/managers/v1/news/articles/${id}`,
+        data,
+      );
     });
   });
 });

--- a/src/services/api/authorsApi/index.test.ts
+++ b/src/services/api/authorsApi/index.test.ts
@@ -12,7 +12,7 @@ describe("authorsApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       authorsApi.getAuthorsList({});
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/news/authors", {
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/news/authors", {
         params,
       });
     });
@@ -30,7 +30,7 @@ describe("authorsApi", () => {
     it("expects to send a post request with the correct info: url and params", () => {
       authorsApi.createAuthor(data);
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/news/authors", data);
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/news/authors", data);
     });
   });
 
@@ -49,7 +49,10 @@ describe("authorsApi", () => {
     it("expects to send a put request with the correct info: url and params", () => {
       authorsApi.updateAuthor(1, data);
 
-      expect(api.put).toHaveBeenCalledWith(`/api/v1/news/authors/${id}`, data);
+      expect(api.put).toHaveBeenCalledWith(
+        `/managers/v1/news/authors/${id}`,
+        data,
+      );
     });
   });
 });

--- a/src/services/api/bigDonorsApi/index.test.ts
+++ b/src/services/api/bigDonorsApi/index.test.ts
@@ -10,7 +10,7 @@ describe("bigDonorsApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       bigDonorsApi.getBigDonorsList();
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/big_donors");
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/big_donors");
     });
   });
 
@@ -22,7 +22,7 @@ describe("bigDonorsApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       bigDonorsApi.getBigDonor("1");
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/big_donors/1");
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/big_donors/1");
     });
   });
 
@@ -39,7 +39,7 @@ describe("bigDonorsApi", () => {
     it("expects to send a post request with the correct info: url and params", () => {
       bigDonorsApi.createBigDonor(data);
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/big_donors", data);
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/big_donors", data);
     });
   });
 
@@ -57,7 +57,7 @@ describe("bigDonorsApi", () => {
     it("expects to send a put request with the correct info: url and params", () => {
       bigDonorsApi.updateBigDonor(data);
 
-      expect(api.put).toHaveBeenCalledWith("/api/v1/big_donors/1", data);
+      expect(api.put).toHaveBeenCalledWith("/managers/v1/big_donors/1", data);
     });
   });
 });

--- a/src/services/api/causesApi/index.test.ts
+++ b/src/services/api/causesApi/index.test.ts
@@ -12,7 +12,7 @@ describe("causesApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       causesApi.getCausesList({});
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/causes", {
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/causes", {
         params,
       });
     });
@@ -30,7 +30,7 @@ describe("causesApi", () => {
     it("expects to send a post request with the correct info: url and params", () => {
       causesApi.createCause(data);
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/causes", data);
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/causes", data);
     });
   });
 
@@ -49,7 +49,7 @@ describe("causesApi", () => {
     it("expects to send a put request with the correct info: url and params", () => {
       causesApi.updateCause(1, data);
 
-      expect(api.put).toHaveBeenCalledWith(`/api/v1/causes/${id}`, data);
+      expect(api.put).toHaveBeenCalledWith(`/managers/v1/causes/${id}`, data);
     });
   });
 });

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -5,7 +5,7 @@ import snakeCaseKeys from "snakecase-keys";
 import { RIBON_API } from "utils/constants";
 
 export const baseURL = RIBON_API;
-export const API_SCOPE = "/api/v1";
+export const API_SCOPE = "/managers/v1";
 
 const api = Axios.create({
   baseURL,

--- a/src/services/api/integrationsApi/index.test.ts
+++ b/src/services/api/integrationsApi/index.test.ts
@@ -11,7 +11,7 @@ describe("integrationsApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       integrationsApi.getIntegrationsList();
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/integrations");
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/integrations");
     });
   });
 
@@ -28,7 +28,7 @@ describe("integrationsApi", () => {
     it("expects to send a post request with the correct info: url and params", () => {
       integrationsApi.createIntegration(data);
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/integrations", data);
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/integrations", data);
     });
   });
 
@@ -62,7 +62,10 @@ describe("integrationsApi", () => {
     it("expects to send a put request with the correct info: url and params", () => {
       integrationsApi.updateIntegration(1, data);
 
-      expect(api.put).toHaveBeenCalledWith(`/api/v1/integrations/${id}`, data);
+      expect(api.put).toHaveBeenCalledWith(
+        `/managers/v1/integrations/${id}`,
+        data,
+      );
     });
   });
 });

--- a/src/services/api/offersApi/index.test.ts
+++ b/src/services/api/offersApi/index.test.ts
@@ -10,12 +10,9 @@ describe("offersApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       offersApi.getOffersList({ perPage: 15, page: 0 });
 
-      expect(api.get).toHaveBeenCalledWith(
-        "/managers/v1/givings/offers_manager",
-        {
-          params: { params: { page: 0, per_page: 15 } },
-        },
-      );
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/givings/offers", {
+        params: { params: { page: 0, per_page: 15 } },
+      });
     });
   });
 });

--- a/src/services/api/offersApi/index.test.ts
+++ b/src/services/api/offersApi/index.test.ts
@@ -10,9 +10,12 @@ describe("offersApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       offersApi.getOffersList({ perPage: 15, page: 0 });
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/givings/offers_manager", {
-        params: { params: { page: 0, per_page: 15 } },
-      });
+      expect(api.get).toHaveBeenCalledWith(
+        "/managers/v1/givings/offers_manager",
+        {
+          params: { params: { page: 0, per_page: 15 } },
+        },
+      );
     });
   });
 });

--- a/src/services/api/offersApi/index.ts
+++ b/src/services/api/offersApi/index.ts
@@ -12,7 +12,7 @@ const offersApi = {
     perPage = 10,
     page = 3,
   }: OffersParams): Promise<AxiosResponse<Offer[]>> =>
-    apiGetWithParams("givings/offers_manager", {
+    apiGetWithParams("givings/offers", {
       params: {
         per_page: perPage,
         page,

--- a/src/services/api/personPaymentsApi/index.test.ts
+++ b/src/services/api/personPaymentsApi/index.test.ts
@@ -10,7 +10,7 @@ describe("personPaymentsApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       personPaymentsApi.getPersonPaymentsList({ page: 1, perPage: 10 });
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/person_payments", {
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/person_payments", {
         params: { params: { page: 1, per_page: 10 } },
       });
     });
@@ -25,7 +25,7 @@ describe("personPaymentsApi", () => {
       personPaymentsApi.getBigDonorsPayments();
 
       expect(api.get).toHaveBeenCalledWith(
-        "/api/v1/person_payments/big_donors",
+        "/managers/v1/person_payments/big_donors",
       );
     });
   });

--- a/src/services/api/poolsApi/index.ts
+++ b/src/services/api/poolsApi/index.ts
@@ -3,8 +3,7 @@ import Pool from "types/entities/Pool";
 import { apiGet } from "..";
 
 const poolsApi = {
-  getPools: (): Promise<AxiosResponse<Pool[]>> =>
-    apiGet("manager/pools_manager"),
+  getPools: (): Promise<AxiosResponse<Pool[]>> => apiGet("/pools"),
 };
 
 export default poolsApi;

--- a/src/services/api/ribonConfigApi/index.test.ts
+++ b/src/services/api/ribonConfigApi/index.test.ts
@@ -10,7 +10,7 @@ describe("ribonConfigApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       ribonConfigApi.getConfig();
 
-      expect(api.get).toHaveBeenCalledWith("/api/v1/configs/settings");
+      expect(api.get).toHaveBeenCalledWith("/managers/v1/configs/settings");
     });
   });
 
@@ -31,7 +31,7 @@ describe("ribonConfigApi", () => {
       ribonConfigApi.updateConfig(id, data);
 
       expect(api.put).toHaveBeenCalledWith(
-        `/api/v1/configs/settings/${id}`,
+        `/managers/v1/configs/settings/${id}`,
         data,
       );
     });

--- a/src/services/api/userApi/index.test.ts
+++ b/src/services/api/userApi/index.test.ts
@@ -10,7 +10,7 @@ describe("usersApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       usersApi.postCreateUser("user@ribon.io");
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/users", {
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/users", {
         email: "user@ribon.io",
       });
     });
@@ -24,7 +24,7 @@ describe("usersApi", () => {
     it("expects to send a get request with the correct info: url, params and headers", () => {
       usersApi.postSearchUser("user@ribon.io");
 
-      expect(api.post).toHaveBeenCalledWith("/api/v1/users/search", {
+      expect(api.post).toHaveBeenCalledWith("/managers/v1/users/search", {
         email: "user@ribon.io",
       });
     });


### PR DESCRIPTION
# Description

- Changes api references in requests to reference managers namespace

## Does this pull request close any open issues?

- [#tech-519](https://ribon.atlassian.net/browse/TECH-519?atlOrigin=eyJpIjoiYjExZWI2OWNjYWEzNDRhYTlkYWVhNDEyZjc5NTkzOWQiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [x] Chore (change that does not effect how the code works, eg: change color)
- [x] Tests

## How to test

- Check if the requests succeed (after the tech-519 PR is also merged on the backend)