### PR TITLE
fix: update cookies to use universal-cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "snakecase-keys": "^5.1.2",
     "styled-components": "^5.3.3",
     "typescript": "^4.8.3",
+    "universal-cookie": "^4.0.4",
     "web-vitals": "^2.1.0",
     "yarn": "^1.22.19"
   },

--- a/src/lib/cookies/index.ts
+++ b/src/lib/cookies/index.ts
@@ -1,23 +1,21 @@
-import Cookies from "js-cookie";
+import Cookies from "universal-cookie";
 
-const isHttpsEnv = process.env.NODE_ENV !== "development";
+export const cookies = new Cookies();
 
 export function setCookiesItem(key: string, value: string): void {
-  Cookies.set(key, value, {
+  cookies.set(key, value, {
     secure: true,
     sameSite: "strict",
-    httpOnly: isHttpsEnv,
   });
 }
 
 export function getCookiesItem(key: string): string | null {
-  return Cookies.get(key) || null;
+  return cookies.get(key) || null;
 }
 
 export function removeCookiesItem(key: string) {
-  Cookies.remove(key, {
+  cookies.remove(key, {
     secure: true,
     sameSite: "strict",
-    httpOnly: isHttpsEnv,
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4960,6 +4960,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -7786,6 +7791,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -17928,6 +17938,14 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+universal-cookie@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Update cookies lib to use `universal-cookie`

The js-cookie lib has some issues in chrome production mode, so we can use this universal-cookie to make it work, maintaining the same lib interface

# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
